### PR TITLE
Model dropdown disabled by default as per #8

### DIFF
--- a/src/main/webapp/txs/TransactionList.jsp
+++ b/src/main/webapp/txs/TransactionList.jsp
@@ -69,7 +69,7 @@
                                 </div>
                                 <div class="form-group col-md-3">
                                     <label for="modelId">Model Name :</label>
-                                    <form:select id="modelId" cssClass="form-control" path="searchTransaction.modelId" tabindex="2">
+                                    <form:select id="modelId" cssClass="form-control" path="searchTransaction.modelId" tabindex="2" disabled="true">
                                         <form:option value=""><spring:message code="common.select" text="<-- Select -->"/></form:option>
                                         <form:options items="${transactionForm.makeAndModelVOs}"
                                                       itemValue="modelId" itemLabel="modelName"/>
@@ -177,6 +177,9 @@
                 $(function() {
                     $("#startDate").datepicker();
                      $("#endDate").datepicker();
+                });
+                $('#makeId').change(function() {
+                    $("#modelId").prop("disabled", false);
                 });
             });
         </script>

--- a/src/main/webapp/txs/TxnAdd.jsp
+++ b/src/main/webapp/txs/TxnAdd.jsp
@@ -145,7 +145,7 @@
                             </td>
                             <td style="text-align:left;">
                                 <form:select id="modelId" path="currentTransaction.modelId" tabindex="2" cssClass="form-control"
-                                             onkeypress="handleEnter(event);">
+                                             onkeypress="handleEnter(event);" disabled="true">
                                     <form:option value=""><spring:message code="common.select" text="<-- Select -->"/></form:option>
                                     <form:options items="${transactionForm.makeAndModelVOs}"
                                                   itemValue="modelId" itemLabel="modelName"/>
@@ -237,6 +237,9 @@
                     });
                     $(function() {
                         $("#dateReported").datepicker();
+                    });
+                    $('#makeId').change(function() {
+                        $("#modelId").prop("disabled", false);
                     });
                 });
             </script>

--- a/src/main/webapp/txs/TxnEdit.jsp
+++ b/src/main/webapp/txs/TxnEdit.jsp
@@ -120,7 +120,7 @@
                         </td>
                         <td style="text-align:left;">
                             <form:select id="modelId" path="currentTransaction.modelId" tabindex="2" cssClass="form-control"
-                                         onkeypress="handleEnter(event);">
+                                         onkeypress="handleEnter(event);" disabled="true">
                                 <form:option value=""><spring:message code="common.select" text="<-- Select -->"/></form:option>
                                 <form:options items="${transactionForm.makeAndModelVOs}"
                                               itemValue="modelId" itemLabel="modelName"/>
@@ -216,6 +216,9 @@
                     });
                     $(function() {
                         $("#dateReported").datepicker();
+                    });
+                    $('#makeId').change(function() {
+                        $("#modelId").prop("disabled", false);
                     });
                 });
             </script>


### PR DESCRIPTION
"Model" dropdown disabled on the following 3 pages by using html property 'disabled'. Using JQuery to enable it back when an option is selected on "Make" dropdown. 

1. Transactions page --> Search Transactions section.
2. Add New Transaction Form page.
3. Edit Transaction Form page

